### PR TITLE
Add state resetting at the end of the request

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -15,6 +15,8 @@ services:
         class: GtmEnhancedEcommercePlugin\TagManager\CheckoutStep
         arguments:
             - "@google_tag_manager"
+        tags:
+            - { name: "kernel.reset", method: "reset" }
 
     sylius.google_tag_manager.enhanced_ecommerce.tracking.resolver.product_detail_impression_data:
         class: GtmEnhancedEcommercePlugin\Resolver\ProductDetailImpressionDataResolver

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -15,8 +15,6 @@ services:
         class: GtmEnhancedEcommercePlugin\TagManager\CheckoutStep
         arguments:
             - "@google_tag_manager"
-        tags:
-            - { name: "kernel.reset", method: "reset" }
 
     sylius.google_tag_manager.enhanced_ecommerce.tracking.resolver.product_detail_impression_data:
         class: GtmEnhancedEcommercePlugin\Resolver\ProductDetailImpressionDataResolver

--- a/src/TagManager/CheckoutStep.php
+++ b/src/TagManager/CheckoutStep.php
@@ -89,4 +89,9 @@ final class CheckoutStep implements CheckoutStepInterface
             'price' => $item->getTotal() / 100,
         ];
     }
+
+    public function reset()
+    {
+        $this->products = [];
+    }
 }

--- a/src/TagManager/CheckoutStep.php
+++ b/src/TagManager/CheckoutStep.php
@@ -20,11 +20,6 @@ final class CheckoutStep implements CheckoutStepInterface
     const STEP_THANKYOU = 6;
 
     /**
-     * @var array
-     */
-    private $products = [];
-
-    /**
      * @var GoogleTagManagerInterface
      */
     private $googleTagManager;
@@ -43,8 +38,9 @@ final class CheckoutStep implements CheckoutStepInterface
      */
     public function addStep(OrderInterface $order, int $step): void
     {
+        $products = [];
         if ($step < self::STEP_THANKYOU) {
-            $this->setProducts($order);
+            $products = $this->getProducts($order);
         }
 
         $checkout = [
@@ -53,8 +49,8 @@ final class CheckoutStep implements CheckoutStepInterface
             ],
         ];
 
-        if (!empty($this->products)) {
-            $checkout['products'] = $this->products;
+        if (!empty($products)) {
+            $checkout['products'] = $products;
         }
 
         $this->googleTagManager->addPush([
@@ -67,20 +63,24 @@ final class CheckoutStep implements CheckoutStepInterface
 
     /**
      * @param OrderInterface $order
+     * @return array
      */
-    private function setProducts(OrderInterface $order): void
+    private function getProducts(OrderInterface $order): array
     {
+        $products = [];
         foreach ($order->getItems() as $item) {
-            $this->addProduct($item);
+            $products[] = $this->createProduct($item);
         }
+        return $products;
     }
 
     /**
      * @param OrderItemInterface $item
+     * @return array
      */
-    private function addProduct(OrderItemInterface $item): void
+    private function createProduct(OrderItemInterface $item): array
     {
-        $this->products[] = [
+        return [
             'name' => $item->getProduct()->getName(),
             'id' => $item->getProduct()->getId(),
             'quantity' => $item->getQuantity(),
@@ -88,10 +88,5 @@ final class CheckoutStep implements CheckoutStepInterface
             'category' => $item->getProduct()->getMainTaxon() ? $item->getProduct()->getMainTaxon()->getName() : '',
             'price' => $item->getTotal() / 100,
         ];
-    }
-
-    public function reset()
-    {
-        $this->products = [];
     }
 }


### PR DESCRIPTION
When using this plugin with https://github.com/php-pm/php-pm the products are added multiple times because they are saved internally and carried over to the next request. This PR fixes this by using Symfony's kernel.reset tag that is designed for this purpose.