### PR TITLE
PR 2 — Introduce Provider pattern and Factories

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: "services/*.yaml" }
+
 services:
 
     sylius.google_tag_manager.enhanced_ecommerce_tracking.tag_manager.add_transaction:

--- a/config/services/factories.yaml
+++ b/config/services/factories.yaml
@@ -1,0 +1,13 @@
+services:
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_item:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmItemFactory
+        arguments:
+            - '@sylius.google_tag_manager.enhanced_ecommerce_tracking.helper.product_identifier'
+    StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmItemFactoryInterface: '@sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_item'
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_ecommerce:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmEcommerceFactory
+        arguments:
+            - '@sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_item'
+    StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmEcommerceFactoryInterface: '@sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_ecommerce'

--- a/config/services/factories.yaml
+++ b/config/services/factories.yaml
@@ -1,5 +1,4 @@
 services:
-
     sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_item:
         class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmItemFactory
         arguments:

--- a/config/services/providers.yaml
+++ b/config/services/providers.yaml
@@ -1,0 +1,59 @@
+services:
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.view_item:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\ViewItemProvider
+        parent: sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.view_item_list
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.view_item_list:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\ViewItemListProvider
+        arguments:
+            - "@sylius.resolver.product_variant"
+            - "@sylius.calculator.product_variant_price"
+            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_item"
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.view_cart:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\ViewCartProvider
+        arguments:
+            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_ecommerce"
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.add_to_cart:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\AddToCartProvider
+        arguments:
+            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_ecommerce"
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.remove_form_cart:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\RemoveFromCartProvider
+        arguments:
+            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_ecommerce"
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.begin_checkout:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\BeginCheckoutProvider
+        arguments:
+            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_ecommerce"
+        tags:
+            - name: sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.checkout_step
+              state: !php/const Sylius\Component\Core\OrderCheckoutStates::STATE_ADDRESSED
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.add_shipping_info:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\AddShippingInfoProvider
+        arguments:
+            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_ecommerce"
+        tags:
+            - name: sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.checkout_step
+              state: !php/const Sylius\Component\Core\OrderCheckoutStates::STATE_SHIPPING_SELECTED
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.add_payment_info:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\AddPaymentInfoProvider
+        arguments:
+            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_ecommerce"
+        tags:
+            - name: sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.checkout_step
+              state: !php/const Sylius\Component\Core\OrderCheckoutStates::STATE_PAYMENT_SELECTED
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.purchase:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\PurchaseProvider
+        arguments:
+            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_ecommerce"
+        tags:
+            - name: sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.checkout_step
+              state: !php/const Sylius\Component\Core\OrderCheckoutStates::STATE_COMPLETED

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -28,3 +28,9 @@ parameters:
           path: tests/Unit/TagManager/AddTransactionTest.php
         - identifier: offsetAccess.nonOffsetAccessible
           path: tests/Unit/TagManager/AddTransactionTest.php
+        - message: "/Cannot access offset ('price'|0) on mixed\\./"
+          path: src/Provider/ViewItemProvider.php
+        - identifier: return.unusedType
+          path: src/Factory/GtmEcommerceFactory.php
+        - identifier: return.type
+          path: src/Factory/GtmEcommerceFactory.php

--- a/src/Factory/GtmEcommerceFactory.php
+++ b/src/Factory/GtmEcommerceFactory.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+
+final class GtmEcommerceFactory implements GtmEcommerceFactoryInterface
+{
+    public function __construct(
+        private GtmItemFactoryInterface $gtmItemFactory,
+    ) {
+    }
+
+    public function createNewFromOrder(OrderInterface $order): ?array
+    {
+        $ecommerce = [
+            'currency' => $order->getCurrencyCode(),
+            'value' => $order->getItemsSubtotal() / 100,
+            'tax' => $order->getTaxTotal() / 100,
+            'shipping' => $order->getShippingTotal() / 100,
+            'items' => $this->getProducts($order),
+        ];
+
+        if ($order->getPromotionCoupon() !== null) {
+            $ecommerce['coupon'] = $order->getPromotionCoupon()->getCode();
+        }
+
+        return $ecommerce;
+    }
+
+    public function createNewFromSingleOrderItem(OrderItemInterface $orderItem, OrderInterface $order): ?array
+    {
+        $ecommerce = [
+            'currency' => $order->getCurrencyCode(),
+            'value' => $orderItem->getTotal() / 100,
+            'tax' => $orderItem->getTaxTotal() / 100,
+            'items' => [
+                $this->gtmItemFactory->createNewFromOrderItem($orderItem, $order),
+            ],
+        ];
+
+        if ($order->getPromotionCoupon() !== null) {
+            $ecommerce['coupon'] = $order->getPromotionCoupon()->getCode();
+        }
+
+        return $ecommerce;
+    }
+
+    public function createNewFromProduct(ProductInterface $product): ?array
+    {
+        return [
+            'items' => [
+                $this->gtmItemFactory->createNewFromProduct($product),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<array<string, mixed>>
+     */
+    private function getProducts(OrderInterface $order): array
+    {
+        $products = [];
+
+        foreach ($order->getItems() as $orderItem) {
+            $products[] = $this->gtmItemFactory->createNewFromOrderItem($orderItem, $order);
+        }
+
+        return $products;
+    }
+}

--- a/src/Factory/GtmEcommerceFactoryInterface.php
+++ b/src/Factory/GtmEcommerceFactoryInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+
+interface GtmEcommerceFactoryInterface
+{
+    /**
+     * @return mixed[]|null
+     */
+    public function createNewFromOrder(OrderInterface $order): ?array;
+
+    /**
+     * @return mixed[]|null
+     */
+    public function createNewFromSingleOrderItem(OrderItemInterface $orderItem, OrderInterface $order): ?array;
+
+    /**
+     * @return mixed[]|null
+     */
+    public function createNewFromProduct(ProductInterface $product): ?array;
+}

--- a/src/Factory/GtmItemFactory.php
+++ b/src/Factory/GtmItemFactory.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory;
+
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\ProductIdentifierHelperInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Webmozart\Assert\Assert;
+
+final class GtmItemFactory implements GtmItemFactoryInterface
+{
+    public function __construct(
+        private ProductIdentifierHelperInterface $productIdentifierHelper,
+    ) {
+    }
+
+    public function createNewFromProduct(ProductInterface $product): array
+    {
+        $data = [
+            'item_id' => $this->productIdentifierHelper->getProductIdentifier($product),
+            'index' => 0,
+        ];
+
+        // item_name is required
+        $productName = $product->getName();
+        if (null !== $productName) {
+            $data['item_name'] = $productName;
+        } else {
+            $data['item_name'] = $data['item_id'];
+        }
+
+        $taxon = $product->getMainTaxon();
+        if (null !== $taxon && null !== $taxon->getName()) {
+            $data['item_category'] = $taxon->getName();
+        }
+
+        return $data;
+    }
+
+    public function createNewFromProductVariant(ProductVariantInterface $productVariant): array
+    {
+        /** @var ProductInterface|null $product */
+        $product = $productVariant->getProduct();
+        Assert::notNull($product, 'Product variant must have a product');
+
+        $data = $this->createNewFromProduct($product);
+
+        $variantName = $productVariant->getName();
+        $variantCode = $productVariant->getCode();
+        if (null !== $variantName || null !== $variantCode) {
+            $data['item_variant'] = $variantName ?? $variantCode;
+        }
+
+        return $data;
+    }
+
+    public function createNewFromOrderItem(OrderItemInterface $orderItem, OrderInterface $order): array
+    {
+        $productVariant = $orderItem->getVariant();
+        Assert::notNull($productVariant, 'Order item must have a variant');
+
+        $index = $order->getItems()->indexOf($orderItem);
+        $index = $index === false ? 0 : $index;
+
+        $data = $this->createNewFromProductVariant($productVariant);
+
+        $data['index'] = $index;
+        $data['price'] = $orderItem->getFullDiscountedUnitPrice() / 100;
+        $data['quantity'] = $orderItem->getQuantity();
+
+        if (null !== $order->getChannel() && null !== $order->getChannel()->getName()) {
+            $data['affiliation'] = $order->getChannel()->getName();
+        }
+
+        return $data;
+    }
+}

--- a/src/Factory/GtmItemFactoryInterface.php
+++ b/src/Factory/GtmItemFactoryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory;
+
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+interface GtmItemFactoryInterface
+{
+    /**
+     * @return mixed[]
+     */
+    public function createNewFromProduct(ProductInterface $product): array;
+
+    /**
+     * @return mixed[]
+     */
+    public function createNewFromProductVariant(ProductVariantInterface $productVariant): array;
+
+    /**
+     * @return mixed[]
+     */
+    public function createNewFromOrderItem(OrderItemInterface $orderItem, OrderInterface $order): array;
+}

--- a/src/Provider/AddPaymentInfoProvider.php
+++ b/src/Provider/AddPaymentInfoProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider;
+
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmEcommerceFactoryInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Payment\Model\PaymentInterface;
+use Webmozart\Assert\Assert;
+
+class AddPaymentInfoProvider implements GtmProviderInterface
+{
+    public function __construct(
+        protected GtmEcommerceFactoryInterface $gtmEcommerceFactory,
+    ) {
+    }
+
+    public function getEvent(array $context): ?string
+    {
+        return 'add_payment_info';
+    }
+
+    public function getEcommerce(array $context): ?array
+    {
+        Assert::keyExists($context, ContextInterface::CONTEXT_ORDER);
+
+        /** @var OrderInterface|null $order */
+        $order = $context[ContextInterface::CONTEXT_ORDER];
+        Assert::isInstanceOf($order, OrderInterface::class);
+
+        $ecommerce = $this->gtmEcommerceFactory->createNewFromOrder($order) ?? [];
+
+        $ecommerce['payment_type'] = implode(
+            ', ',
+            $order->getPayments()->map(function (PaymentInterface $payment) {
+                return $payment->getMethod()?->getName();
+            })->toArray(),
+        );
+
+        return $ecommerce;
+    }
+}

--- a/src/Provider/AddShippingInfoProvider.php
+++ b/src/Provider/AddShippingInfoProvider.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider;
+
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmEcommerceFactoryInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\ShipmentInterface;
+use Webmozart\Assert\Assert;
+
+class AddShippingInfoProvider implements GtmProviderInterface
+{
+    public function __construct(
+        protected GtmEcommerceFactoryInterface $gtmEcommerceFactory,
+    ) {
+    }
+
+    public function getEvent(array $context): ?string
+    {
+        return 'add_shipping_info';
+    }
+
+    public function getEcommerce(array $context): ?array
+    {
+        Assert::keyExists($context, ContextInterface::CONTEXT_ORDER);
+
+        /** @var OrderInterface|null $order */
+        $order = $context[ContextInterface::CONTEXT_ORDER];
+        Assert::isInstanceOf($order, OrderInterface::class);
+
+        $ecommerce = $this->gtmEcommerceFactory->createNewFromOrder($order) ?? [];
+
+        $ecommerce['shipping_tier'] = implode(
+            ', ',
+            $order->getShipments()->map(function (ShipmentInterface $shipment) {
+                return $shipment->getMethod()?->getName();
+            })->toArray(),
+        );
+
+        return $ecommerce;
+    }
+}

--- a/src/Provider/AddToCartProvider.php
+++ b/src/Provider/AddToCartProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider;
+
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmEcommerceFactoryInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Webmozart\Assert\Assert;
+
+class AddToCartProvider implements GtmProviderInterface
+{
+    public function __construct(
+        protected GtmEcommerceFactoryInterface $gtmEcommerceFactory,
+    ) {
+    }
+
+    public function getEvent(array $context): ?string
+    {
+        return 'add_to_cart';
+    }
+
+    public function getEcommerce(array $context): ?array
+    {
+        Assert::keyExists($context, ContextInterface::CONTEXT_ORDER_ITEM);
+        Assert::keyExists($context, ContextInterface::CONTEXT_ORDER);
+
+        /** @var OrderItemInterface|null $orderItem */
+        $orderItem = $context[ContextInterface::CONTEXT_ORDER_ITEM] ?? null;
+        Assert::isInstanceOf($orderItem, OrderItemInterface::class);
+
+        /** @var OrderInterface|null $order */
+        $order = $context[ContextInterface::CONTEXT_ORDER] ?? null;
+        Assert::isInstanceOf($order, OrderInterface::class);
+
+        return $this->gtmEcommerceFactory->createNewFromSingleOrderItem($orderItem, $order);
+    }
+}

--- a/src/Provider/BeginCheckoutProvider.php
+++ b/src/Provider/BeginCheckoutProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider;
+
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmEcommerceFactoryInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Webmozart\Assert\Assert;
+
+class BeginCheckoutProvider implements GtmProviderInterface
+{
+    public function __construct(
+        protected GtmEcommerceFactoryInterface $gtmEcommerceFactory,
+    ) {
+    }
+
+    public function getEvent(array $context): ?string
+    {
+        return 'begin_checkout';
+    }
+
+    public function getEcommerce(array $context): ?array
+    {
+        Assert::keyExists($context, ContextInterface::CONTEXT_ORDER);
+
+        /** @var OrderInterface|null $order */
+        $order = $context[ContextInterface::CONTEXT_ORDER];
+        Assert::isInstanceOf($order, OrderInterface::class);
+
+        return $this->gtmEcommerceFactory->createNewFromOrder($order);
+    }
+}

--- a/src/Provider/GtmProviderInterface.php
+++ b/src/Provider/GtmProviderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider;
+
+interface GtmProviderInterface
+{
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function getEvent(array $context): ?string;
+
+    /**
+     * @param array<string, mixed> $context
+     *
+     * @return mixed[]|null
+     */
+    public function getEcommerce(array $context): ?array;
+}

--- a/src/Provider/PurchaseProvider.php
+++ b/src/Provider/PurchaseProvider.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider;
+
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmEcommerceFactoryInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Webmozart\Assert\Assert;
+
+class PurchaseProvider implements GtmProviderInterface
+{
+    public function __construct(
+        protected GtmEcommerceFactoryInterface $gtmEcommerceFactory,
+    ) {
+    }
+
+    public function getEvent(array $context): ?string
+    {
+        return 'purchase';
+    }
+
+    public function getEcommerce(array $context): ?array
+    {
+        Assert::keyExists($context, ContextInterface::CONTEXT_ORDER);
+
+        /** @var OrderInterface|null $order */
+        $order = $context[ContextInterface::CONTEXT_ORDER];
+        Assert::isInstanceOf($order, OrderInterface::class);
+
+        $ecommerce = $this->gtmEcommerceFactory->createNewFromOrder($order) ?? [];
+
+        /** https://developers.google.com/analytics/devguides/collection/ga4/ecommerce?client_type=gtm&hl=fr#purchase-gtm */
+        $ecommerce['transaction_id'] = $order->getNumber();
+
+        return $ecommerce;
+    }
+}

--- a/src/Provider/RemoveFromCartProvider.php
+++ b/src/Provider/RemoveFromCartProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider;
+
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmEcommerceFactoryInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Webmozart\Assert\Assert;
+
+class RemoveFromCartProvider implements GtmProviderInterface
+{
+    public function __construct(
+        protected GtmEcommerceFactoryInterface $gtmEcommerceFactory,
+    ) {
+    }
+
+    public function getEvent(array $context): ?string
+    {
+        return 'remove_from_cart';
+    }
+
+    public function getEcommerce(array $context): ?array
+    {
+        Assert::keyExists($context, ContextInterface::CONTEXT_ORDER_ITEM);
+        Assert::keyExists($context, ContextInterface::CONTEXT_ORDER);
+
+        /** @var OrderItemInterface|null $orderItem */
+        $orderItem = $context[ContextInterface::CONTEXT_ORDER_ITEM] ?? null;
+        Assert::isInstanceOf($orderItem, OrderItemInterface::class);
+
+        /** @var OrderInterface|null $order */
+        $order = $context[ContextInterface::CONTEXT_ORDER] ?? null;
+        Assert::isInstanceOf($order, OrderInterface::class);
+
+        return $this->gtmEcommerceFactory->createNewFromSingleOrderItem($orderItem, $order);
+    }
+}

--- a/src/Provider/ViewCartProvider.php
+++ b/src/Provider/ViewCartProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider;
+
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmEcommerceFactoryInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Webmozart\Assert\Assert;
+
+class ViewCartProvider implements GtmProviderInterface
+{
+    public function __construct(
+        protected GtmEcommerceFactoryInterface $gtmEcommerceFactory,
+    ) {
+    }
+
+    public function getEvent(array $context): ?string
+    {
+        return 'view_cart';
+    }
+
+    public function getEcommerce(array $context): ?array
+    {
+        Assert::keyExists($context, ContextInterface::CONTEXT_ORDER);
+
+        /** @var OrderInterface|null $order */
+        $order = $context[ContextInterface::CONTEXT_ORDER];
+        Assert::isInstanceOf($order, OrderInterface::class);
+
+        return $this->gtmEcommerceFactory->createNewFromOrder($order) ?? [];
+    }
+}

--- a/src/Provider/ViewItemListProvider.php
+++ b/src/Provider/ViewItemListProvider.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider;
+
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmItemFactoryInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
+use Webmozart\Assert\Assert;
+
+class ViewItemListProvider implements GtmProviderInterface
+{
+    public function __construct(
+        protected ProductVariantResolverInterface $productVariantResolver,
+        protected ProductVariantPricesCalculatorInterface $productVariantPricesCalculator,
+        protected GtmItemFactoryInterface $gtmItemFactory,
+    ) {
+    }
+
+    public function getEvent(array $context): ?string
+    {
+        return 'view_item_list';
+    }
+
+    public function getEcommerce(array $context): ?array
+    {
+        Assert::keyExists($context, ContextInterface::CONTEXT_PRODUCTS);
+        Assert::keyExists($context, ContextInterface::CONTEXT_CURRENCY_CODE);
+        Assert::keyExists($context, ContextInterface::CONTEXT_CHANNEL);
+
+        /** @var TaxonInterface|mixed $taxon */
+        $taxon = $context[ContextInterface::CONTEXT_TAXON] ?? null;
+        Assert::nullOrIsInstanceOf($taxon, TaxonInterface::class);
+
+        /** @var array<ProductInterface|mixed> $products */
+        $products = $context[ContextInterface::CONTEXT_PRODUCTS];
+        Assert::allIsInstanceOf($products, ProductInterface::class);
+
+        /** @var string|mixed $currencyCode */
+        $currencyCode = $context[ContextInterface::CONTEXT_CURRENCY_CODE];
+        Assert::notNull($currencyCode, 'Currency code should not be null');
+
+        /** @var ChannelInterface|mixed $channel */
+        $channel = $context[ContextInterface::CONTEXT_CHANNEL];
+        Assert::isInstanceOf($channel, ChannelInterface::class);
+
+        $index = 0;
+        $ecommerce = [
+            'currency' => $currencyCode,
+            'items' => array_values(array_filter(array_map(function (ProductInterface $product) use ($channel, &$index): ?array {
+                /** @var ProductVariantInterface|null $productVariant */
+                $productVariant = $this->productVariantResolver->getVariant($product);
+                if (null === $productVariant) {
+                    return null;
+                }
+
+                $item = $this->gtmItemFactory->createNewFromProductVariant($productVariant);
+
+                $item['price'] = $this->productVariantPricesCalculator->calculate($productVariant, ['channel' => $channel]) / 100;
+                $item['affiliation'] = $channel->getName();
+                $item['index'] = $index++;
+
+                return $item;
+            }, $products))),
+        ];
+
+        if (null !== $taxon) {
+            $ecommerce['item_list_id'] = $taxon->getCode();
+            $ecommerce['item_list_name'] = $taxon->getName();
+        }
+
+        return $ecommerce;
+    }
+}

--- a/src/Provider/ViewItemProvider.php
+++ b/src/Provider/ViewItemProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider;
+
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Webmozart\Assert\Assert;
+
+class ViewItemProvider extends ViewItemListProvider
+{
+    public function getEvent(array $context): ?string
+    {
+        return 'view_item';
+    }
+
+    public function getEcommerce(array $context): ?array
+    {
+        Assert::keyExists($context, ContextInterface::CONTEXT_PRODUCT);
+
+        /** @var ProductInterface|mixed $product */
+        $product = $context[ContextInterface::CONTEXT_PRODUCT];
+        Assert::isInstanceOf($product, ProductInterface::class);
+
+        $context[ContextInterface::CONTEXT_PRODUCTS] = [$product];
+
+        $ecommerce = parent::getEcommerce($context);
+        if (null === $ecommerce) {
+            return null;
+        }
+
+        $ecommerce['value'] = $ecommerce['items'][0]['price'] ?? 0.0;
+
+        return $ecommerce;
+    }
+}

--- a/src/TagManager/ContextInterface.php
+++ b/src/TagManager/ContextInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager;
+
+interface ContextInterface
+{
+    public const CONTEXT_ORDER = 'order';
+
+    public const CONTEXT_ORDER_ITEM = 'order_item';
+
+    public const CONTEXT_PRODUCT = 'product';
+
+    public const CONTEXT_PRODUCTS = 'products';
+
+    public const CONTEXT_CURRENCY_CODE = 'currency_code';
+
+    public const CONTEXT_CHANNEL = 'channel';
+
+    public const CONTEXT_TAXON = 'taxon';
+}

--- a/tests/Unit/Provider/ViewCartProviderTest.php
+++ b/tests/Unit/Provider/ViewCartProviderTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Unit\Provider;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmEcommerceFactoryInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\ViewCartProvider;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+
+final class ViewCartProviderTest extends TestCase
+{
+    private MockObject&GtmEcommerceFactoryInterface $gtmEcommerceFactory;
+
+    private ViewCartProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->gtmEcommerceFactory = $this->createMock(GtmEcommerceFactoryInterface::class);
+        $this->provider = new ViewCartProvider($this->gtmEcommerceFactory);
+    }
+
+    public function testEventReturnsCorrectConstant(): void
+    {
+        self::assertSame('view_cart', $this->provider->getEvent([]));
+    }
+
+    public function testGetEcommerceReturnsDataFromFactory(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+        $expected = [
+            'currency' => 'EUR',
+            'value' => 49.99,
+            'items' => [
+                [
+                    'id' => 'product456',
+                ],
+            ],
+        ];
+
+        $this->gtmEcommerceFactory->expects($this->once())
+            ->method('createNewFromOrder')
+            ->with($order)
+            ->willReturn($expected);
+
+        $result = $this->provider->getEcommerce([
+            ContextInterface::CONTEXT_ORDER => $order,
+        ]);
+
+        self::assertSame($expected, $result);
+    }
+
+    public function testGetEcommerceThrowsExceptionWhenOrderKeyMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->provider->getEcommerce([]);
+    }
+
+    public function testGetEcommerceThrowsExceptionWhenOrderIsNotValid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->provider->getEcommerce([
+            ContextInterface::CONTEXT_ORDER => new \stdClass(),
+        ]);
+    }
+
+    public function testGetEcommerceReturnsEmptyArrayWhenFactoryReturnsNull(): void
+    {
+        $order = $this->createMock(OrderInterface::class);
+
+        $this->gtmEcommerceFactory->expects($this->once())
+            ->method('createNewFromOrder')
+            ->with($order)
+            ->willReturn(null);
+
+        $result = $this->provider->getEcommerce([
+            ContextInterface::CONTEXT_ORDER => $order,
+        ]);
+
+        self::assertSame([], $result);
+    }
+}

--- a/tests/Unit/Provider/ViewItemListProviderTest.php
+++ b/tests/Unit/Provider/ViewItemListProviderTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Unit\Provider;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmItemFactoryInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\ViewItemListProvider;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
+
+final class ViewItemListProviderTest extends TestCase
+{
+    private MockObject&ProductVariantResolverInterface $productVariantResolver;
+
+    private MockObject&ProductVariantPricesCalculatorInterface $productVariantPricesCalculator;
+
+    private MockObject&GtmItemFactoryInterface $gtmItemFactory;
+
+    private ViewItemListProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->productVariantResolver = $this->createMock(ProductVariantResolverInterface::class);
+        $this->productVariantPricesCalculator = $this->createMock(ProductVariantPricesCalculatorInterface::class);
+        $this->gtmItemFactory = $this->createMock(GtmItemFactoryInterface::class);
+        $this->provider = new ViewItemListProvider(
+            $this->productVariantResolver,
+            $this->productVariantPricesCalculator,
+            $this->gtmItemFactory,
+        );
+    }
+
+    public function testEventReturnsCorrectConstant(): void
+    {
+        self::assertSame('view_item_list', $this->provider->getEvent([]));
+    }
+
+    public function testGetEcommerceReturnsDataWithProducts(): void
+    {
+        $product = $this->createMock(ProductInterface::class);
+        $productVariant = $this->createMock(ProductVariantInterface::class);
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $this->productVariantResolver->expects($this->once())
+            ->method('getVariant')
+            ->with($product)
+            ->willReturn($productVariant);
+
+        $this->productVariantPricesCalculator->expects($this->once())
+            ->method('calculate')
+            ->with($productVariant, ['channel' => $channel])
+            ->willReturn(1999);
+
+        $this->gtmItemFactory->expects($this->once())
+            ->method('createNewFromProductVariant')
+            ->with($productVariant)
+            ->willReturn(['id' => 'product123', 'name' => 'Product Name']);
+
+        $channel->expects($this->once())
+            ->method('getName')
+            ->willReturn('Web Store');
+
+        $result = $this->provider->getEcommerce([
+            ContextInterface::CONTEXT_PRODUCTS => [$product],
+            ContextInterface::CONTEXT_CURRENCY_CODE => 'USD',
+            ContextInterface::CONTEXT_CHANNEL => $channel,
+        ]);
+
+        $expected = [
+            'currency' => 'USD',
+            'items' => [
+                [
+                    'id' => 'product123',
+                    'name' => 'Product Name',
+                    'price' => 19.99,
+                    'affiliation' => 'Web Store',
+                    'index' => 0,
+                ],
+            ],
+        ];
+
+        self::assertEquals($expected, $result);
+    }
+
+    public function testGetEcommerceIncludesTaxonDataWhenAvailable(): void
+    {
+        $product = $this->createMock(ProductInterface::class);
+        $productVariant = $this->createMock(ProductVariantInterface::class);
+        $channel = $this->createMock(ChannelInterface::class);
+        $taxon = $this->createMock(TaxonInterface::class);
+
+        $this->productVariantResolver->expects($this->once())
+            ->method('getVariant')
+            ->willReturn($productVariant);
+
+        $this->productVariantPricesCalculator->expects($this->once())
+            ->method('calculate')
+            ->willReturn(2500);
+
+        $this->gtmItemFactory->expects($this->once())
+            ->method('createNewFromProductVariant')
+            ->willReturn(['id' => 'product456']);
+
+        $channel->method('getName')->willReturn('Web Store');
+        $taxon->method('getCode')->willReturn('category-code');
+        $taxon->method('getName')->willReturn('Category Name');
+
+        $result = $this->provider->getEcommerce([
+            ContextInterface::CONTEXT_PRODUCTS => [$product],
+            ContextInterface::CONTEXT_CURRENCY_CODE => 'EUR',
+            ContextInterface::CONTEXT_CHANNEL => $channel,
+            ContextInterface::CONTEXT_TAXON => $taxon,
+        ]);
+
+        $expected = [
+            'currency' => 'EUR',
+            'item_list_id' => 'category-code',
+            'item_list_name' => 'Category Name',
+            'items' => [
+                [
+                    'id' => 'product456',
+                    'price' => 25,
+                    'affiliation' => 'Web Store',
+                    'index' => 0,
+                ],
+            ],
+        ];
+
+        self::assertEquals($expected, $result);
+    }
+
+    public function testGetEcommerceWithEmptyProductsArray(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $result = $this->provider->getEcommerce([
+            ContextInterface::CONTEXT_PRODUCTS => [],
+            ContextInterface::CONTEXT_CURRENCY_CODE => 'USD',
+            ContextInterface::CONTEXT_CHANNEL => $channel,
+        ]);
+
+        $expected = [
+            'currency' => 'USD',
+            'items' => [],
+        ];
+
+        self::assertEquals($expected, $result);
+    }
+
+    public function testGetEcommerceSkipsProductsWithNoVariant(): void
+    {
+        $product1 = $this->createMock(ProductInterface::class);
+        $product2 = $this->createMock(ProductInterface::class);
+        $productVariant = $this->createMock(ProductVariantInterface::class);
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $this->productVariantResolver->expects($this->exactly(2))
+            ->method('getVariant')
+            ->willReturnOnConsecutiveCalls(null, $productVariant);
+
+        $this->productVariantPricesCalculator->expects($this->once())
+            ->method('calculate')
+            ->willReturn(1000);
+
+        $this->gtmItemFactory->expects($this->once())
+            ->method('createNewFromProductVariant')
+            ->willReturn(['id' => 'product789']);
+
+        $channel->method('getName')->willReturn('Web Store');
+
+        $result = $this->provider->getEcommerce([
+            ContextInterface::CONTEXT_PRODUCTS => [$product1, $product2],
+            ContextInterface::CONTEXT_CURRENCY_CODE => 'USD',
+            ContextInterface::CONTEXT_CHANNEL => $channel,
+        ]);
+
+        $expected = [
+            'currency' => 'USD',
+            'items' => [
+                [
+                    'id' => 'product789',
+                    'price' => 10,
+                    'affiliation' => 'Web Store',
+                    'index' => 0,
+                ],
+            ],
+        ];
+
+        self::assertEquals($expected, $result);
+    }
+
+    public function testGetEcommerceThrowsExceptionWhenRequiredKeysAreMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->provider->getEcommerce([]);
+    }
+
+    public function testGetEcommerceThrowsExceptionWhenInvalidChannelProvided(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->provider->getEcommerce([
+            ContextInterface::CONTEXT_PRODUCTS => [],
+            ContextInterface::CONTEXT_CURRENCY_CODE => 'USD',
+            ContextInterface::CONTEXT_CHANNEL => new \stdClass(),
+        ]);
+    }
+
+    public function testGetEcommerceThrowsExceptionWhenInvalidTaxonProvided(): void
+    {
+        $channel = $this->createMock(ChannelInterface::class);
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->provider->getEcommerce([
+            ContextInterface::CONTEXT_PRODUCTS => [],
+            ContextInterface::CONTEXT_CURRENCY_CODE => 'USD',
+            ContextInterface::CONTEXT_CHANNEL => $channel,
+            ContextInterface::CONTEXT_TAXON => new \stdClass(),
+        ]);
+    }
+}

--- a/tests/Unit/Provider/ViewItemProviderTest.php
+++ b/tests/Unit/Provider/ViewItemProviderTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Unit\Provider;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmItemFactoryInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\ViewItemProvider;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
+
+final class ViewItemProviderTest extends TestCase
+{
+    private MockObject&ProductVariantResolverInterface $productVariantResolver;
+
+    private MockObject&ProductVariantPricesCalculatorInterface $productVariantPricesCalculator;
+
+    private MockObject&GtmItemFactoryInterface $gtmItemFactory;
+
+    private ViewItemProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->productVariantResolver = $this->createMock(ProductVariantResolverInterface::class);
+        $this->productVariantPricesCalculator = $this->createMock(ProductVariantPricesCalculatorInterface::class);
+        $this->gtmItemFactory = $this->createMock(GtmItemFactoryInterface::class);
+        $this->provider = new ViewItemProvider(
+            $this->productVariantResolver,
+            $this->productVariantPricesCalculator,
+            $this->gtmItemFactory,
+        );
+    }
+
+    public function testEventReturnsCorrectConstant(): void
+    {
+        self::assertSame('view_item', $this->provider->getEvent([]));
+    }
+
+    public function testGetEcommerceCallsParentWithProductInProductsArray(): void
+    {
+        $product = $this->createMock(ProductInterface::class);
+        $productVariant = $this->createMock(ProductVariantInterface::class);
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $this->productVariantResolver->expects($this->once())
+            ->method('getVariant')
+            ->with($product)
+            ->willReturn($productVariant);
+
+        $this->productVariantPricesCalculator->expects($this->once())
+            ->method('calculate')
+            ->with($productVariant, ['channel' => $channel])
+            ->willReturn(1500);
+
+        $this->gtmItemFactory->expects($this->once())
+            ->method('createNewFromProductVariant')
+            ->with($productVariant)
+            ->willReturn(['id' => 'product123', 'name' => 'Test Product']);
+
+        $channel->expects($this->once())
+            ->method('getName')
+            ->willReturn('Web Store');
+
+        $result = $this->provider->getEcommerce([
+            ContextInterface::CONTEXT_PRODUCT => $product,
+            ContextInterface::CONTEXT_CURRENCY_CODE => 'EUR',
+            ContextInterface::CONTEXT_CHANNEL => $channel,
+        ]);
+
+        $expected = [
+            'currency' => 'EUR',
+            'value' => 15,
+            'items' => [
+                [
+                    'id' => 'product123',
+                    'name' => 'Test Product',
+                    'price' => 15,
+                    'affiliation' => 'Web Store',
+                    'index' => 0,
+                ],
+            ],
+        ];
+
+        self::assertEquals($expected, $result);
+    }
+
+    public function testGetEcommerceThrowsExceptionWhenProductKeyIsMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->provider->getEcommerce([
+            ContextInterface::CONTEXT_CURRENCY_CODE => 'USD',
+            ContextInterface::CONTEXT_CHANNEL => $this->createMock(ChannelInterface::class),
+        ]);
+    }
+
+    public function testGetEcommerceThrowsExceptionWhenProductIsNotValid(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->provider->getEcommerce([
+            ContextInterface::CONTEXT_PRODUCT => new \stdClass(),
+            ContextInterface::CONTEXT_CURRENCY_CODE => 'USD',
+            ContextInterface::CONTEXT_CHANNEL => $this->createMock(ChannelInterface::class),
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

Add the new Provider pattern and Factory classes for GTM Enhanced Ecommerce events. This is **PR 2 of 6** in the series to modernize this plugin for Sylius 2.0 (splitting the work from #221).

This is purely additive — no existing code is modified.

## Changes

### New: Provider pattern
- `src/Provider/GtmProviderInterface.php` — Common interface for all providers
- 9 concrete providers: ViewItemList, ViewItem, ViewCart, AddToCart, RemoveFromCart, BeginCheckout, AddShippingInfo, AddPaymentInfo, Purchase

### New: Factory classes
- `src/Factory/GtmItemFactory.php` + interface — Creates GTM item data from products/variants/order items
- `src/Factory/GtmEcommerceFactory.php` + interface — Creates GTM ecommerce data from orders

### New: Context interface
- `src/TagManager/ContextInterface.php` — Constants for context array keys

### New: Service configuration
- `config/services/factories.yaml` — Factory service definitions
- `config/services/providers.yaml` — Provider service definitions with tagged locator support

### New: Unit tests
- 3 test files, 17 new tests for ViewItem, ViewItemList, and ViewCart providers

## Verification

- ✅ All 42 PHPUnit tests pass (25 existing + 17 new)
- ✅ PHPStan analysis passes
- ✅ ECS coding standard passes

## Related
- Depends on #223 (merged)
- Next: PR 4 (Refactor TagManagers to use Providers)
