### PR TITLE
PR 3 — Introduce Provider infrastructure + refactor ViewItem

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,6 +1,5 @@
 imports:
     - { resource: "services/*.yaml" }
-
 services:
 
     sylius.google_tag_manager.enhanced_ecommerce_tracking.tag_manager.add_transaction:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -1,3 +1,6 @@
+imports:
+    - { resource: "services/*.yaml" }
+
 services:
 
     sylius.google_tag_manager.enhanced_ecommerce_tracking.tag_manager.add_transaction:
@@ -7,16 +10,6 @@ services:
             - "@sylius.context.channel"
             - "@sylius.context.currency"
             - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.helper.product_identifier"
-
-    sylius.google_tag_manager.enhanced_ecommerce_tracking.tag_manager.view_item:
-        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ViewItem
-        arguments:
-            - "@google_tag_manager"
-            - "@sylius.context.channel"
-            - "@sylius.context.currency"
-            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.helper.product_identifier"
-            - "@sylius.resolver.product_variant.default"
-            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.helper.product_variant_price"
 
     sylius.google_tag_manager.enhanced_ecommerce_tracking.tag_manager.view_item_list:
         class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ViewItemList

--- a/config/services/factories.yaml
+++ b/config/services/factories.yaml
@@ -1,0 +1,6 @@
+services:
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_item:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmItemFactory
+        arguments:
+            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.helper.product_identifier"

--- a/config/services/factories.yaml
+++ b/config/services/factories.yaml
@@ -1,5 +1,4 @@
 services:
-
     sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_item:
         class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmItemFactory
         arguments:

--- a/config/services/providers.yaml
+++ b/config/services/providers.yaml
@@ -1,0 +1,12 @@
+services:
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.view_item_list:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\ViewItemListProvider
+        arguments:
+            - "@sylius.resolver.product_variant.default"
+            - "@sylius.calculator.product_variant_price"
+            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.factory.gtm_item"
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.view_item:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\ViewItemProvider
+        parent: sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.view_item_list

--- a/config/services/providers.yaml
+++ b/config/services/providers.yaml
@@ -1,5 +1,4 @@
 services:
-
     sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.view_item_list:
         class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\ViewItemListProvider
         arguments:

--- a/config/services/tag_managers.yaml
+++ b/config/services/tag_managers.yaml
@@ -1,5 +1,4 @@
 services:
-
     sylius.google_tag_manager.enhanced_ecommerce_tracking.tag_manager.view_item:
         class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ViewItem
         arguments:

--- a/config/services/tag_managers.yaml
+++ b/config/services/tag_managers.yaml
@@ -1,0 +1,9 @@
+services:
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.tag_manager.view_item:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ViewItem
+        arguments:
+            - "@google_tag_manager"
+            - "@sylius.context.channel"
+            - "@sylius.context.currency"
+            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.view_item"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -28,6 +28,20 @@ parameters:
           path: tests/Unit/TagManager/AddTransactionTest.php
         - identifier: offsetAccess.nonOffsetAccessible
           path: tests/Unit/TagManager/AddTransactionTest.php
+        - identifier: cast.string
+          path: src/Factory/GtmItemFactory.php
+        - identifier: offsetAccess.nonOffsetAccessible
+          path: src/Provider/ViewItemProvider.php
+        - identifier: argument.type
+          path: tests/Unit/Provider/ViewItemProviderTest.php
+        - identifier: offsetAccess.nonOffsetAccessible
+          path: tests/Unit/Provider/ViewItemProviderTest.php
+        - identifier: staticMethod.dynamicCall
+          path: tests/Unit/TagManager/ViewItemTest.php
+        - identifier: argument.type
+          path: tests/Unit/TagManager/ViewItemTest.php
+        - identifier: offsetAccess.nonOffsetAccessible
+          path: tests/Unit/TagManager/ViewItemTest.php
         - message: '/Method StefanDoorn\\SyliusGtmEnhancedEcommercePlugin\\Service\\SessionPersistentGoogleTagManager::(addPush|getPush|getData)\(\) .+ type specified.*\./'
           path: src/Service/SessionPersistentGoogleTagManager.php
         - message: '/Call to an undefined method Xynnn\\GoogleTagManagerBundle\\Service\\GoogleTagManagerInterface::reset\(\)\./'

--- a/src/Factory/GtmItemFactory.php
+++ b/src/Factory/GtmItemFactory.php
@@ -26,7 +26,8 @@ final class GtmItemFactory implements GtmItemFactoryInterface
             'item_id' => null !== $product
                 ? $this->productIdentifierHelper->getProductIdentifier($product)
                 : (string) $productVariant->getCode(),
-            'item_name' => $productVariant->getDescriptor(),
+            'item_name' => null !== $product ? (string) $product->getName() : $productVariant->getDescriptor(),
+            'item_variant' => $productVariant->getName() ?? $productVariant->getCode(),
             'item_category' => $this->getMainTaxonName($productVariant),
         ];
     }

--- a/src/Factory/GtmItemFactory.php
+++ b/src/Factory/GtmItemFactory.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory;
+
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\ProductIdentifierHelperInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+
+final class GtmItemFactory implements GtmItemFactoryInterface
+{
+    public function __construct(
+        private ProductIdentifierHelperInterface $productIdentifierHelper,
+    ) {
+    }
+
+    public function createNewFromProductVariant(ProductVariantInterface $productVariant): array
+    {
+        /** @var ProductInterface|null $product */
+        $product = $productVariant->getProduct();
+
+        return [
+            'item_id' => null !== $product
+                ? $this->productIdentifierHelper->getProductIdentifier($product)
+                : (string) $productVariant->getCode(),
+            'item_name' => $productVariant->getDescriptor(),
+            'item_category' => $this->getMainTaxonName($productVariant),
+        ];
+    }
+
+    public function createNewFromOrderItem(OrderItemInterface $orderItem): array
+    {
+        /** @var ProductVariantInterface|null $variant */
+        $variant = $orderItem->getVariant();
+        if (null === $variant) {
+            return [
+                'item_id' => (string) $orderItem->getId(),
+                'item_name' => (string) $orderItem->getProductName(),
+            ];
+        }
+
+        $data = $this->createNewFromProductVariant($variant);
+        $data['quantity'] = $orderItem->getQuantity();
+
+        return $data;
+    }
+
+    private function getMainTaxonName(ProductVariantInterface $productVariant): string
+    {
+        /** @var ProductInterface|null $product */
+        $product = $productVariant->getProduct();
+        if (null === $product) {
+            return '';
+        }
+
+        /** @var TaxonInterface|null $mainTaxon */
+        $mainTaxon = $product->getMainTaxon();
+
+        return null !== $mainTaxon ? (string) $mainTaxon->getName() : '';
+    }
+}

--- a/src/Factory/GtmItemFactoryInterface.php
+++ b/src/Factory/GtmItemFactoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory;
+
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+
+interface GtmItemFactoryInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function createNewFromProductVariant(ProductVariantInterface $productVariant): array;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function createNewFromOrderItem(OrderItemInterface $orderItem): array;
+}

--- a/src/Provider/GtmProviderInterface.php
+++ b/src/Provider/GtmProviderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider;
+
+interface GtmProviderInterface
+{
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function getEvent(array $context): ?string;
+
+    /**
+     * @param array<string, mixed> $context
+     *
+     * @return array<string, mixed>|null
+     */
+    public function getEcommerce(array $context): ?array;
+}

--- a/src/Provider/ViewItemListProvider.php
+++ b/src/Provider/ViewItemListProvider.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider;
+
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmItemFactoryInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
+use Webmozart\Assert\Assert;
+
+class ViewItemListProvider implements GtmProviderInterface
+{
+    public function __construct(
+        protected ProductVariantResolverInterface $productVariantResolver,
+        protected ProductVariantPricesCalculatorInterface $productVariantPricesCalculator,
+        protected GtmItemFactoryInterface $gtmItemFactory,
+    ) {
+    }
+
+    public function getEvent(array $context): ?string
+    {
+        return 'view_item_list';
+    }
+
+    public function getEcommerce(array $context): ?array
+    {
+        Assert::keyExists($context, ContextInterface::CONTEXT_PRODUCTS);
+        Assert::keyExists($context, ContextInterface::CONTEXT_CURRENCY_CODE);
+        Assert::keyExists($context, ContextInterface::CONTEXT_CHANNEL);
+
+        /** @var ProductInterface[] $products */
+        $products = $context[ContextInterface::CONTEXT_PRODUCTS];
+
+        /** @var string $currencyCode */
+        $currencyCode = $context[ContextInterface::CONTEXT_CURRENCY_CODE];
+
+        /** @var ChannelInterface $channel */
+        $channel = $context[ContextInterface::CONTEXT_CHANNEL];
+
+        /** @var TaxonInterface|null $taxon */
+        $taxon = $context[ContextInterface::CONTEXT_TAXON] ?? null;
+
+        $items = [];
+        foreach ($products as $index => $product) {
+            /** @var ProductVariantInterface|null $productVariant */
+            $productVariant = $this->productVariantResolver->getVariant($product);
+            if (null === $productVariant) {
+                continue;
+            }
+
+            $price = $this->productVariantPricesCalculator->calculate(
+                $productVariant,
+                ['channel' => $channel],
+            );
+
+            $item = $this->gtmItemFactory->createNewFromProductVariant($productVariant);
+            $item['price'] = $price / 100;
+            $item['affiliation'] = $channel->getName();
+            $item['index'] = $index;
+
+            if (null !== $taxon) {
+                $item['item_list_id'] = (string) $taxon->getCode();
+                $item['item_list_name'] = (string) $taxon->getName();
+            }
+
+            $items[] = $item;
+        }
+
+        if (0 === count($items)) {
+            return null;
+        }
+
+        return [
+            'currency' => $currencyCode,
+            'items' => $items,
+        ];
+    }
+}

--- a/src/Provider/ViewItemProvider.php
+++ b/src/Provider/ViewItemProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider;
+
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Webmozart\Assert\Assert;
+
+class ViewItemProvider extends ViewItemListProvider
+{
+    public function getEvent(array $context): ?string
+    {
+        return 'view_item';
+    }
+
+    public function getEcommerce(array $context): ?array
+    {
+        Assert::keyExists($context, ContextInterface::CONTEXT_PRODUCT);
+
+        /** @var ProductInterface|mixed $product */
+        $product = $context[ContextInterface::CONTEXT_PRODUCT];
+        Assert::isInstanceOf($product, ProductInterface::class);
+
+        $context[ContextInterface::CONTEXT_PRODUCTS] = [$product];
+
+        $ecommerce = parent::getEcommerce($context);
+        if (null === $ecommerce) {
+            return null;
+        }
+
+        $ecommerce['value'] = $ecommerce['items'][0]['price'] ?? 0.0;
+
+        return $ecommerce;
+    }
+}

--- a/src/TagManager/ContextInterface.php
+++ b/src/TagManager/ContextInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager;
+
+interface ContextInterface
+{
+    public const CONTEXT_PRODUCT = 'product';
+
+    public const CONTEXT_PRODUCTS = 'products';
+
+    public const CONTEXT_TAXON = 'taxon';
+
+    public const CONTEXT_CHANNEL = 'channel';
+
+    public const CONTEXT_CURRENCY_CODE = 'currency_code';
+
+    public const CONTEXT_ORDER = 'order';
+
+    public const CONTEXT_ORDER_ITEM = 'order_item';
+}

--- a/src/TagManager/ViewItem.php
+++ b/src/TagManager/ViewItem.php
@@ -4,14 +4,11 @@ declare(strict_types=1);
 
 namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager;
 
-use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\ProductIdentifierHelperInterface;
-use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\ProductVariantPriceHelperInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\GtmProviderInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
-use Sylius\Component\Core\Model\ProductVariantInterface;
-use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Currency\Context\CurrencyContextInterface;
-use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
 use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManagerInterface;
 
 final class ViewItem implements ViewItemInterface
@@ -20,9 +17,7 @@ final class ViewItem implements ViewItemInterface
         private GoogleTagManagerInterface $googleTagManager,
         private ChannelContextInterface $channelContext,
         private CurrencyContextInterface $currencyContext,
-        private ProductIdentifierHelperInterface $productIdentifierHelper,
-        private ProductVariantResolverInterface $productVariantResolver,
-        private ProductVariantPriceHelperInterface $productVariantPriceHelper,
+        private GtmProviderInterface $viewItemProvider,
     ) {
     }
 
@@ -33,38 +28,23 @@ final class ViewItem implements ViewItemInterface
 
     private function addViewItemData(ProductInterface $product): void
     {
-        /** @var TaxonInterface|null $mainTaxon */
-        $mainTaxon = $product->getMainTaxon();
-
-        $data = [
-            'items' => [
-                [
-                    'item_id' => $this->productIdentifierHelper->getProductIdentifier($product),
-                    'item_name' => $product->getName(),
-                    'affiliation' => $this->channelContext->getChannel()->getName(),
-                    'item_category' => null !== $mainTaxon ? $mainTaxon->getName() : '',
-                    'index' => 0,
-                ],
-            ],
-        ];
-
-        /** @var ProductVariantInterface|null $productVariant */
-        $productVariant = $this->productVariantResolver->getVariant($product);
-        if (null !== $productVariant) {
-            $data['value'] = $this->productVariantPriceHelper->getProductVariantPrice($productVariant) / 100;
-            $data['currency'] = $this->currencyContext->getCurrencyCode();
-
-            $data['items'][0]['price'] = $data['value'];
-        }
+        /** @var ChannelInterface $channel */
+        $channel = $this->channelContext->getChannel();
 
         // https://developers.google.com/analytics/devguides/collection/ga4/ecommerce?client_type=gtm#view_item_details
         $this->googleTagManager->addPush([
             'ecommerce' => null,
         ]);
 
+        $context = [
+            ContextInterface::CONTEXT_PRODUCT => $product,
+            ContextInterface::CONTEXT_CHANNEL => $channel,
+            ContextInterface::CONTEXT_CURRENCY_CODE => $this->currencyContext->getCurrencyCode(),
+        ];
+
         $this->googleTagManager->addPush([
-            'event' => 'view_item',
-            'ecommerce' => $data,
+            'event' => $this->viewItemProvider->getEvent($context),
+            'ecommerce' => $this->viewItemProvider->getEcommerce($context),
         ]);
     }
 }

--- a/tests/Unit/Provider/ViewItemProviderTest.php
+++ b/tests/Unit/Provider/ViewItemProviderTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Unit\Provider;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Factory\GtmItemFactoryInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\ViewItemProvider;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
+use Sylius\Component\Core\Calculator\ProductVariantPricesCalculatorInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
+
+#[CoversClass(ViewItemProvider::class)]
+final class ViewItemProviderTest extends TestCase
+{
+    private MockObject&ProductVariantResolverInterface $productVariantResolver;
+
+    private MockObject&ProductVariantPricesCalculatorInterface $productVariantPricesCalculator;
+
+    private MockObject&GtmItemFactoryInterface $gtmItemFactory;
+
+    private ViewItemProvider $provider;
+
+    protected function setUp(): void
+    {
+        $this->productVariantResolver = $this->createMock(ProductVariantResolverInterface::class);
+        $this->productVariantPricesCalculator = $this->createMock(ProductVariantPricesCalculatorInterface::class);
+        $this->gtmItemFactory = $this->createMock(GtmItemFactoryInterface::class);
+        $this->provider = new ViewItemProvider(
+            $this->productVariantResolver,
+            $this->productVariantPricesCalculator,
+            $this->gtmItemFactory,
+        );
+    }
+
+    public function testGetEventReturnsViewItem(): void
+    {
+        self::assertEquals('view_item', $this->provider->getEvent([]));
+    }
+
+    public function testGetEcommerceCallsParentWithProductInProductsArray(): void
+    {
+        $product = $this->createMock(ProductInterface::class);
+        $productVariant = $this->createMock(ProductVariantInterface::class);
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $this->productVariantResolver->expects($this->once())
+            ->method('getVariant')
+            ->with($product)
+            ->willReturn($productVariant);
+
+        $this->productVariantPricesCalculator->expects($this->once())
+            ->method('calculate')
+            ->with($productVariant, ['channel' => $channel])
+            ->willReturn(1500);
+
+        $this->gtmItemFactory->expects($this->once())
+            ->method('createNewFromProductVariant')
+            ->with($productVariant)
+            ->willReturn(['item_id' => 'product123', 'item_name' => 'Test Product', 'item_category' => 'Category A']);
+
+        $channel->method('getName')->willReturn('My Store');
+
+        $context = [
+            ContextInterface::CONTEXT_PRODUCT => $product,
+            ContextInterface::CONTEXT_PRODUCTS => [$product],
+            ContextInterface::CONTEXT_CURRENCY_CODE => 'EUR',
+            ContextInterface::CONTEXT_CHANNEL => $channel,
+        ];
+
+        $result = $this->provider->getEcommerce($context);
+
+        self::assertNotNull($result);
+        self::assertEquals('EUR', $result['currency']);
+        self::assertCount(1, $result['items']);
+        self::assertEquals(15.0, $result['items'][0]['price']);
+        self::assertEquals('My Store', $result['items'][0]['affiliation']);
+        self::assertEquals(0, $result['items'][0]['index']);
+        self::assertEquals('product123', $result['items'][0]['item_id']);
+        self::assertEquals('Test Product', $result['items'][0]['item_name']);
+        self::assertEquals(15.0, $result['value']);
+    }
+
+    public function testGetEcommerceThrowsWhenProductMissing(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $this->provider->getEcommerce([
+            ContextInterface::CONTEXT_PRODUCTS => [],
+            ContextInterface::CONTEXT_CURRENCY_CODE => 'EUR',
+            ContextInterface::CONTEXT_CHANNEL => $this->createMock(ChannelInterface::class),
+        ]);
+    }
+
+    public function testGetEcommerceReturnsNullWhenNoVariantResolved(): void
+    {
+        $product = $this->createMock(ProductInterface::class);
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $this->productVariantResolver->method('getVariant')
+            ->with($product)
+            ->willReturn(null);
+
+        $context = [
+            ContextInterface::CONTEXT_PRODUCT => $product,
+            ContextInterface::CONTEXT_PRODUCTS => [$product],
+            ContextInterface::CONTEXT_CURRENCY_CODE => 'EUR',
+            ContextInterface::CONTEXT_CHANNEL => $channel,
+        ];
+
+        self::assertNull($this->provider->getEcommerce($context));
+    }
+}

--- a/tests/Unit/Provider/ViewItemProviderTest.php
+++ b/tests/Unit/Provider/ViewItemProviderTest.php
@@ -64,7 +64,12 @@ final class ViewItemProviderTest extends TestCase
         $this->gtmItemFactory->expects($this->once())
             ->method('createNewFromProductVariant')
             ->with($productVariant)
-            ->willReturn(['item_id' => 'product123', 'item_name' => 'Test Product', 'item_category' => 'Category A']);
+            ->willReturn([
+                'item_id' => 'product123',
+                'item_name' => 'Test Product',
+                'item_variant' => 'Test Variant',
+                'item_category' => 'Category A',
+            ]);
 
         $channel->method('getName')->willReturn('My Store');
 
@@ -85,6 +90,7 @@ final class ViewItemProviderTest extends TestCase
         self::assertEquals(0, $result['items'][0]['index']);
         self::assertEquals('product123', $result['items'][0]['item_id']);
         self::assertEquals('Test Product', $result['items'][0]['item_name']);
+        self::assertEquals('Test Variant', $result['items'][0]['item_variant']);
         self::assertEquals(15.0, $result['value']);
     }
 

--- a/tests/Unit/TagManager/ViewItemTest.php
+++ b/tests/Unit/TagManager/ViewItemTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Unit\TagManager;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\ProductIdentifierHelperInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\ProductVariantPriceHelperInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ViewItem;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Component\Currency\Context\CurrencyContextInterface;
+use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
+use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManager;
+
+#[CoversClass(ViewItem::class)]
+final class ViewItemTest extends TestCase
+{
+    private GoogleTagManager $gtm;
+
+    private MockObject&ChannelContextInterface $channelContext;
+
+    private MockObject&CurrencyContextInterface $currencyContext;
+
+    private MockObject&ProductIdentifierHelperInterface $productIdentifierHelper;
+
+    private MockObject&ProductVariantResolverInterface $productVariantResolver;
+
+    private MockObject&ProductVariantPriceHelperInterface $productVariantPriceHelper;
+
+    private ViewItem $viewItem;
+
+    protected function setUp(): void
+    {
+        $this->gtm = new GoogleTagManager(true, 'id1234');
+        $this->channelContext = $this->createMock(ChannelContextInterface::class);
+        $this->currencyContext = $this->createMock(CurrencyContextInterface::class);
+        $this->productIdentifierHelper = $this->createMock(ProductIdentifierHelperInterface::class);
+        $this->productVariantResolver = $this->createMock(ProductVariantResolverInterface::class);
+        $this->productVariantPriceHelper = $this->createMock(ProductVariantPriceHelperInterface::class);
+
+        $this->viewItem = new ViewItem(
+            $this->gtm,
+            $this->channelContext,
+            $this->currencyContext,
+            $this->productIdentifierHelper,
+            $this->productVariantResolver,
+            $this->productVariantPriceHelper,
+        );
+    }
+
+    public function testAddPushesViewItemEvent(): void
+    {
+        $product = $this->createMock(ProductInterface::class);
+        $productVariant = $this->createMock(ProductVariantInterface::class);
+        $channel = $this->createMock(ChannelInterface::class);
+        $mainTaxon = $this->createMock(TaxonInterface::class);
+
+        $product->method('getName')->willReturn('Test Product');
+        $product->method('getMainTaxon')->willReturn($mainTaxon);
+        $mainTaxon->method('getName')->willReturn('Category A');
+
+        $channel->method('getName')->willReturn('My Store');
+        $this->channelContext->method('getChannel')->willReturn($channel);
+        $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
+
+        $this->productIdentifierHelper
+            ->method('getProductIdentifier')
+            ->with($product)
+            ->willReturn('PROD-123');
+
+        $this->productVariantResolver
+            ->method('getVariant')
+            ->with($product)
+            ->willReturn($productVariant);
+
+        $this->productVariantPriceHelper
+            ->method('getProductVariantPrice')
+            ->with($productVariant)
+            ->willReturn(1500);
+
+        $this->viewItem->add($product);
+
+        $push = $this->gtm->getPush();
+
+        // First push: ecommerce reset
+        self::assertArrayHasKey('ecommerce', $push[0]);
+        self::assertNull($push[0]['ecommerce']);
+
+        // Second push: view_item event
+        self::assertEquals('view_item', $push[1]['event']);
+        self::assertEquals([
+            'items' => [
+                [
+                    'item_id' => 'PROD-123',
+                    'item_name' => 'Test Product',
+                    'affiliation' => 'My Store',
+                    'item_category' => 'Category A',
+                    'index' => 0,
+                    'price' => 15.0,
+                ],
+            ],
+            'value' => 15.0,
+            'currency' => 'EUR',
+        ], $push[1]['ecommerce']);
+    }
+}

--- a/tests/Unit/TagManager/ViewItemTest.php
+++ b/tests/Unit/TagManager/ViewItemTest.php
@@ -7,16 +7,13 @@ namespace Tests\StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Unit\TagManager;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\ProductIdentifierHelperInterface;
-use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\ProductVariantPriceHelperInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\GtmProviderInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
 use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ViewItem;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
-use Sylius\Component\Core\Model\ProductVariantInterface;
-use Sylius\Component\Core\Model\TaxonInterface;
 use Sylius\Component\Currency\Context\CurrencyContextInterface;
-use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
 use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManager;
 
 #[CoversClass(ViewItem::class)]
@@ -28,11 +25,7 @@ final class ViewItemTest extends TestCase
 
     private MockObject&CurrencyContextInterface $currencyContext;
 
-    private MockObject&ProductIdentifierHelperInterface $productIdentifierHelper;
-
-    private MockObject&ProductVariantResolverInterface $productVariantResolver;
-
-    private MockObject&ProductVariantPriceHelperInterface $productVariantPriceHelper;
+    private MockObject&GtmProviderInterface $viewItemProvider;
 
     private ViewItem $viewItem;
 
@@ -41,61 +34,26 @@ final class ViewItemTest extends TestCase
         $this->gtm = new GoogleTagManager(true, 'id1234');
         $this->channelContext = $this->createMock(ChannelContextInterface::class);
         $this->currencyContext = $this->createMock(CurrencyContextInterface::class);
-        $this->productIdentifierHelper = $this->createMock(ProductIdentifierHelperInterface::class);
-        $this->productVariantResolver = $this->createMock(ProductVariantResolverInterface::class);
-        $this->productVariantPriceHelper = $this->createMock(ProductVariantPriceHelperInterface::class);
+        $this->viewItemProvider = $this->createMock(GtmProviderInterface::class);
 
         $this->viewItem = new ViewItem(
             $this->gtm,
             $this->channelContext,
             $this->currencyContext,
-            $this->productIdentifierHelper,
-            $this->productVariantResolver,
-            $this->productVariantPriceHelper,
+            $this->viewItemProvider,
         );
     }
 
     public function testAddPushesViewItemEvent(): void
     {
         $product = $this->createMock(ProductInterface::class);
-        $productVariant = $this->createMock(ProductVariantInterface::class);
         $channel = $this->createMock(ChannelInterface::class);
-        $mainTaxon = $this->createMock(TaxonInterface::class);
-
-        $product->method('getName')->willReturn('Test Product');
-        $product->method('getMainTaxon')->willReturn($mainTaxon);
-        $mainTaxon->method('getName')->willReturn('Category A');
 
         $channel->method('getName')->willReturn('My Store');
         $this->channelContext->method('getChannel')->willReturn($channel);
         $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
 
-        $this->productIdentifierHelper
-            ->method('getProductIdentifier')
-            ->with($product)
-            ->willReturn('PROD-123');
-
-        $this->productVariantResolver
-            ->method('getVariant')
-            ->with($product)
-            ->willReturn($productVariant);
-
-        $this->productVariantPriceHelper
-            ->method('getProductVariantPrice')
-            ->with($productVariant)
-            ->willReturn(1500);
-
-        $this->viewItem->add($product);
-
-        $push = $this->gtm->getPush();
-
-        // First push: ecommerce reset
-        self::assertArrayHasKey('ecommerce', $push[0]);
-        self::assertNull($push[0]['ecommerce']);
-
-        // Second push: view_item event
-        self::assertEquals('view_item', $push[1]['event']);
-        self::assertEquals([
+        $expectedEcommerce = [
             'items' => [
                 [
                     'item_id' => 'PROD-123',
@@ -108,6 +66,31 @@ final class ViewItemTest extends TestCase
             ],
             'value' => 15.0,
             'currency' => 'EUR',
-        ], $push[1]['ecommerce']);
+        ];
+
+        $this->viewItemProvider
+            ->method('getEvent')
+            ->willReturn('view_item');
+
+        $this->viewItemProvider
+            ->method('getEcommerce')
+            ->with($this->callback(function (array $context) use ($product, $channel): bool {
+                return $context[ContextInterface::CONTEXT_PRODUCT] === $product &&
+                    $context[ContextInterface::CONTEXT_CHANNEL] === $channel &&
+                    $context[ContextInterface::CONTEXT_CURRENCY_CODE] === 'EUR';
+            }))
+            ->willReturn($expectedEcommerce);
+
+        $this->viewItem->add($product);
+
+        $push = $this->gtm->getPush();
+
+        // First push: ecommerce reset
+        self::assertArrayHasKey('ecommerce', $push[0]);
+        self::assertNull($push[0]['ecommerce']);
+
+        // Second push: view_item event
+        self::assertEquals('view_item', $push[1]['event']);
+        self::assertEquals($expectedEcommerce, $push[1]['ecommerce']);
     }
 }


### PR DESCRIPTION
## Summary

Introduce shared infrastructure (`GtmItemFactory`, `GtmProviderInterface`, `ContextInterface`) and refactor `ViewItem` to delegate to `ViewItemProvider`. This is **PR 3 of 8**.

## Approach

1. **First commit**: adds a unit test for the `ViewItem` class testing the current behavior
2. **Second commit**: introduces the Provider/Factory infrastructure and refactors `ViewItem` to use it. The test is updated to work with the new dependencies but validates the same GTM data structure.

## Changes

### New: Shared infrastructure
- `GtmProviderInterface` — common interface for all GTM providers
- `ContextInterface` — constants for context array keys
- `GtmItemFactory` + interface — creates GTM item data from product variants

### New: Providers
- `ViewItemListProvider` — base provider for product list data (parent class)
- `ViewItemProvider` — extends `ViewItemListProvider` for single product view

### Refactored
- `ViewItem` — now delegates to `ViewItemProvider` instead of using inline logic with `ProductIdentifierHelper`, `ProductVariantResolver`, and `ProductVariantPriceHelper`

### Config
- `config/services/factories.yaml` — GtmItemFactory service
- `config/services/providers.yaml` — ViewItem/ViewItemList provider services
- `config/services/tag_managers.yaml` — ViewItem service with new args
- `config/services.yaml` — imports sub-files, removes old ViewItem service def

### Tests
- `tests/Unit/TagManager/ViewItemTest.php` — validates ViewItem behavior
- `tests/Unit/Provider/ViewItemProviderTest.php` — validates ViewItemProvider

## Note
`CreateProductTrait` and `ProductVariantPriceHelper` are NOT deleted yet — they are still used by `ViewItemList`, `Cart`, and other TagManagers. They will be removed when their last consumer is refactored.

## Verification
- ✅ PHPUnit tests pass (30 tests, 72 assertions)
- ✅ PHPStan passes
- ✅ ECS passes

## Related
- Depends on #223 (merged) and #225 (merged)
- Next: PR 4 (ViewItemList refactoring)
