### PR TITLE
PR 4 — Refactor ViewItemList + ViewItemListListener

### DIFF
--- a/config/features/view_item_list.yaml
+++ b/config/features/view_item_list.yaml
@@ -3,9 +3,7 @@ services:
   sylius.google_tag_manager.enhanced_ecommerce_tracking.view_item_list.listener:
     class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\EventListener\ViewItemListListener
     arguments:
-      - "@sylius.repository.taxon"
-      - "@sylius.context.locale"
-      - "@security.firewall.map"
       - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.tag_manager.view_item_list"
+      - "@sylius_shop.twig.component.product.breadcrumb"
     tags:
-      - { name: kernel.event_listener, event: kernel.controller }
+      - { name: kernel.event_listener, event: sylius.product.index }

--- a/config/features/view_item_list.yaml
+++ b/config/features/view_item_list.yaml
@@ -1,5 +1,4 @@
 services:
-
   sylius.google_tag_manager.enhanced_ecommerce_tracking.view_item_list.listener:
     class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\EventListener\ViewItemListListener
     arguments:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -10,17 +10,6 @@ services:
             - "@sylius.context.currency"
             - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.helper.product_identifier"
 
-    sylius.google_tag_manager.enhanced_ecommerce_tracking.tag_manager.view_item_list:
-        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ViewItemList
-        arguments:
-            - "@google_tag_manager"
-            - "@sylius.repository.product"
-            - "@sylius.context.channel"
-            - "@sylius.context.locale"
-            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.helper.product_identifier"
-            - "@sylius.resolver.product_variant.default"
-            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.helper.product_variant_price"
-
     sylius.google_tag_manager.enhanced_ecommerce_tracking.tag_manager.checkout_step:
         class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\CheckoutStep
         arguments:

--- a/config/services/tag_managers.yaml
+++ b/config/services/tag_managers.yaml
@@ -6,3 +6,11 @@ services:
             - "@sylius.context.channel"
             - "@sylius.context.currency"
             - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.view_item"
+
+    sylius.google_tag_manager.enhanced_ecommerce_tracking.tag_manager.view_item_list:
+        class: StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ViewItemList
+        arguments:
+            - "@google_tag_manager"
+            - "@sylius.context.channel"
+            - "@sylius.context.currency"
+            - "@sylius.google_tag_manager.enhanced_ecommerce_tracking.provider.view_item_list"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -42,6 +42,12 @@ parameters:
           path: tests/Unit/TagManager/ViewItemTest.php
         - identifier: offsetAccess.nonOffsetAccessible
           path: tests/Unit/TagManager/ViewItemTest.php
+        - identifier: missingType.generics
+          path: tests/Unit/TagManager/ViewItemListTest.php
+        - identifier: argument.type
+          path: tests/Unit/TagManager/ViewItemListTest.php
+        - identifier: offsetAccess.nonOffsetAccessible
+          path: tests/Unit/TagManager/ViewItemListTest.php
         - message: '/Method StefanDoorn\\SyliusGtmEnhancedEcommercePlugin\\Service\\SessionPersistentGoogleTagManager::(addPush|getPush|getData)\(\) .+ type specified.*\./'
           path: src/Service/SessionPersistentGoogleTagManager.php
         - message: '/Call to an undefined method Xynnn\\GoogleTagManagerBundle\\Service\\GoogleTagManagerInterface::reset\(\)\./'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -18,10 +18,7 @@ parameters:
           path: src/Helper/ProductIdentifierHelper.php
         - identifier: binaryOp.invalid
           path: src/TagManager/Cart.php
-        - identifier: argument.type
-          path: src/TagManager/ViewItemList.php
-        - identifier: arrayFilter.strict
-          path: src/TagManager/ViewItemList.php
+
         - identifier: argument.type
           path: tests/Unit/EventListener/ThankYouListenerTest.php
         - identifier: argument.type
@@ -42,7 +39,7 @@ parameters:
           path: tests/Unit/TagManager/ViewItemTest.php
         - identifier: offsetAccess.nonOffsetAccessible
           path: tests/Unit/TagManager/ViewItemTest.php
-        - identifier: missingType.generics
+        - identifier: staticMethod.dynamicCall
           path: tests/Unit/TagManager/ViewItemListTest.php
         - identifier: argument.type
           path: tests/Unit/TagManager/ViewItemListTest.php

--- a/src/EventListener/ViewItemListListener.php
+++ b/src/EventListener/ViewItemListListener.php
@@ -4,57 +4,38 @@ declare(strict_types=1);
 
 namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\EventListener;
 
-use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\MainRequest\ControllerEventMainRequest;
 use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ViewItemListInterface;
-use Sylius\Component\Core\Model\TaxonInterface;
-use Sylius\Component\Locale\Context\LocaleContextInterface;
-use Sylius\Component\Taxonomy\Repository\TaxonRepositoryInterface;
-use Symfony\Bundle\SecurityBundle\Security\FirewallMap;
-use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Sylius\Bundle\ShopBundle\Twig\Component\Product\BreadcrumbComponent;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Grid\View\GridViewInterface;
+use Sylius\Resource\Symfony\EventDispatcher\GenericEvent;
 
 final class ViewItemListListener
 {
-    /**
-     * @param TaxonRepositoryInterface<TaxonInterface> $taxonRepository
-     */
     public function __construct(
-        private TaxonRepositoryInterface $taxonRepository,
-        private LocaleContextInterface $localeContext,
-        private FirewallMap $firewallMap,
         private ViewItemListInterface $viewItemList,
+        private BreadcrumbComponent $breadcrumbComponent,
     ) {
     }
 
-    public function __invoke(ControllerEvent $event): void
+    public function __invoke(GenericEvent $event): void
     {
-        if (!ControllerEventMainRequest::isMainRequest($event)) {
+        try {
+            $taxon = $this->breadcrumbComponent->taxon();
+        } catch (\InvalidArgumentException) {
             return;
         }
 
-        $request = $event->getRequest();
+        /** @var GridViewInterface $gridView */
+        $gridView = $event->getSubject();
 
-        $firewallConfig = $this->firewallMap->getFirewallConfig($request);
-        if (null !== $firewallConfig && 'shop' !== $firewallConfig->getName()) {
-            return;
+        $products = [];
+        /** @var iterable<ProductInterface> $data */
+        $data = $gridView->getData();
+        foreach ($data as $product) {
+            $products[] = $product;
         }
 
-        if ('sylius_shop_product_index' !== $request->get('_route')) {
-            return;
-        }
-
-        /** @var string|null $slug */
-        $slug = $request->get('slug');
-
-        if (null === $slug) {
-            return;
-        }
-
-        $taxon = $this->taxonRepository->findOneBySlug($slug, $this->localeContext->getLocaleCode());
-
-        if (!$taxon instanceof TaxonInterface) {
-            return;
-        }
-
-        $this->viewItemList->add($taxon, $request->get('_route'));
+        $this->viewItemList->add($taxon, $products);
     }
 }

--- a/src/TagManager/ViewItemList.php
+++ b/src/TagManager/ViewItemList.php
@@ -4,78 +4,43 @@ declare(strict_types=1);
 
 namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\ProductIdentifierHelperInterface;
-use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\ProductVariantPriceHelperInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\GtmProviderInterface;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
-use Sylius\Component\Core\Model\ProductInterface;
-use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
-use Sylius\Component\Core\Repository\ProductRepositoryInterface;
-use Sylius\Component\Locale\Context\LocaleContextInterface;
-use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
+use Sylius\Component\Currency\Context\CurrencyContextInterface;
 use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManagerInterface;
 
 final class ViewItemList implements ViewItemListInterface
 {
-    /**
-     * @param ProductRepositoryInterface<ProductInterface> $productRepository
-     */
     public function __construct(
         private GoogleTagManagerInterface $googleTagManager,
-        private ProductRepositoryInterface $productRepository,
         private ChannelContextInterface $channelContext,
-        private LocaleContextInterface $localeContext,
-        private ProductIdentifierHelperInterface $productIdentifierHelper,
-        private ProductVariantResolverInterface $productVariantResolver,
-        private ProductVariantPriceHelperInterface $productVariantPriceHelper,
+        private CurrencyContextInterface $currencyContext,
+        private GtmProviderInterface $viewItemListProvider,
     ) {
     }
 
-    public function add(TaxonInterface $taxon, ?string $listId = null): void
+    public function add(TaxonInterface $taxon, array $products): void
     {
-        $this->addViewItemListData($taxon, $listId);
+        $this->addViewItemListData($taxon, $products);
     }
 
-    private function addViewItemListData(TaxonInterface $taxon, ?string $listId = null): void
+    /** @param \Sylius\Component\Core\Model\ProductInterface[] $products */
+    private function addViewItemListData(TaxonInterface $taxon, array $products): void
     {
-        /** @var ChannelInterface $channel */
-        $channel = $this->channelContext->getChannel();
-        $products = new ArrayCollection(
-            $this->productRepository->createShopListQueryBuilder(
-                $channel,
-                $taxon,
-                $this->localeContext->getLocaleCode(),
-            )->getQuery()->getResult(),
-        );
-
-        if (0 === $products->count()) {
+        if (0 === \count($products)) {
             return;
         }
 
-        $index = 0;
+        /** @var ChannelInterface $channel */
+        $channel = $this->channelContext->getChannel();
 
-        $data = [
-            'item_list_id' => $listId,
-            'item_list_name' => $taxon->getName(),
-            'items' => $products->map(function (ProductInterface $product) use ($taxon, &$index): array {
-                $productData = [
-                    'item_id' => $this->productIdentifierHelper->getProductIdentifier($product),
-                    'item_name' => $product->getName(),
-                    'affiliation' => $this->channelContext->getChannel()->getName(),
-                    'item_category' => $taxon->getName(),
-                    'index' => $index++,
-                ];
-
-                /** @var ProductVariantInterface|null $productVariant */
-                $productVariant = $this->productVariantResolver->getVariant($product);
-                if (null !== $productVariant) {
-                    $productData['price'] = $this->productVariantPriceHelper->getProductVariantPrice($productVariant) / 100;
-                }
-
-                return $productData;
-            })->toArray(),
+        $context = [
+            ContextInterface::CONTEXT_PRODUCTS => $products,
+            ContextInterface::CONTEXT_TAXON => $taxon,
+            ContextInterface::CONTEXT_CHANNEL => $channel,
+            ContextInterface::CONTEXT_CURRENCY_CODE => $this->currencyContext->getCurrencyCode(),
         ];
 
         // https://developers.google.com/analytics/devguides/collection/ga4/ecommerce?client_type=gtm#view_item_details
@@ -84,8 +49,8 @@ final class ViewItemList implements ViewItemListInterface
         ]);
 
         $this->googleTagManager->addPush([
-            'event' => 'view_item_list',
-            'ecommerce' => \array_filter($data),
+            'event' => $this->viewItemListProvider->getEvent($context),
+            'ecommerce' => $this->viewItemListProvider->getEcommerce($context),
         ]);
     }
 }

--- a/src/TagManager/ViewItemListInterface.php
+++ b/src/TagManager/ViewItemListInterface.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager;
 
+use Sylius\Component\Core\Model\ProductInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
 
 interface ViewItemListInterface
 {
-    public function add(TaxonInterface $taxon, ?string $listId = null): void;
+    /** @param ProductInterface[] $products */
+    public function add(TaxonInterface $taxon, array $products): void;
 }

--- a/tests/Unit/TagManager/ViewItemListTest.php
+++ b/tests/Unit/TagManager/ViewItemListTest.php
@@ -4,22 +4,17 @@ declare(strict_types=1);
 
 namespace Tests\StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Unit\TagManager;
 
-use Doctrine\ORM\Query;
-use Doctrine\ORM\QueryBuilder;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\ProductIdentifierHelperInterface;
-use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\ProductVariantPriceHelperInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Provider\GtmProviderInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ContextInterface;
 use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ViewItemList;
 use Sylius\Component\Channel\Context\ChannelContextInterface;
 use Sylius\Component\Core\Model\ChannelInterface;
 use Sylius\Component\Core\Model\ProductInterface;
-use Sylius\Component\Core\Model\ProductVariantInterface;
 use Sylius\Component\Core\Model\TaxonInterface;
-use Sylius\Component\Core\Repository\ProductRepositoryInterface;
-use Sylius\Component\Locale\Context\LocaleContextInterface;
-use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
+use Sylius\Component\Currency\Context\CurrencyContextInterface;
 use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManager;
 
 #[CoversClass(ViewItemList::class)]
@@ -27,84 +22,68 @@ final class ViewItemListTest extends TestCase
 {
     private GoogleTagManager $gtm;
 
-    private MockObject&ProductRepositoryInterface $productRepository;
-
     private MockObject&ChannelContextInterface $channelContext;
 
-    private MockObject&LocaleContextInterface $localeContext;
+    private MockObject&CurrencyContextInterface $currencyContext;
 
-    private MockObject&ProductIdentifierHelperInterface $productIdentifierHelper;
-
-    private MockObject&ProductVariantResolverInterface $productVariantResolver;
-
-    private MockObject&ProductVariantPriceHelperInterface $productVariantPriceHelper;
+    private MockObject&GtmProviderInterface $viewItemListProvider;
 
     private ViewItemList $viewItemList;
 
     protected function setUp(): void
     {
         $this->gtm = new GoogleTagManager(true, 'id1234');
-        $this->productRepository = $this->createMock(ProductRepositoryInterface::class);
         $this->channelContext = $this->createMock(ChannelContextInterface::class);
-        $this->localeContext = $this->createMock(LocaleContextInterface::class);
-        $this->productIdentifierHelper = $this->createMock(ProductIdentifierHelperInterface::class);
-        $this->productVariantResolver = $this->createMock(ProductVariantResolverInterface::class);
-        $this->productVariantPriceHelper = $this->createMock(ProductVariantPriceHelperInterface::class);
+        $this->currencyContext = $this->createMock(CurrencyContextInterface::class);
+        $this->viewItemListProvider = $this->createMock(GtmProviderInterface::class);
 
         $this->viewItemList = new ViewItemList(
             $this->gtm,
-            $this->productRepository,
             $this->channelContext,
-            $this->localeContext,
-            $this->productIdentifierHelper,
-            $this->productVariantResolver,
-            $this->productVariantPriceHelper,
+            $this->currencyContext,
+            $this->viewItemListProvider,
         );
     }
 
     public function testAddPushesViewItemListEvent(): void
     {
         $taxon = $this->createMock(TaxonInterface::class);
-        $taxon->method('getName')->willReturn('Electronics');
-
         $channel = $this->createMock(ChannelInterface::class);
-        $channel->method('getName')->willReturn('My Store');
+        $product = $this->createMock(ProductInterface::class);
 
         $this->channelContext->method('getChannel')->willReturn($channel);
-        $this->localeContext->method('getLocaleCode')->willReturn('en_US');
+        $this->currencyContext->method('getCurrencyCode')->willReturn('EUR');
 
-        $product = $this->createMock(ProductInterface::class);
-        $product->method('getName')->willReturn('Test Product');
+        $expectedEcommerce = [
+            'items' => [
+                [
+                    'item_id' => 'PROD-1',
+                    'item_name' => 'Test Product',
+                    'affiliation' => 'My Store',
+                    'item_category' => 'Electronics',
+                    'item_list_id' => 'ELECTRONICS',
+                    'item_list_name' => 'Electronics',
+                    'index' => 0,
+                    'price' => 15.0,
+                ],
+            ],
+        ];
 
-        $variant = $this->createMock(ProductVariantInterface::class);
+        $this->viewItemListProvider
+            ->method('getEvent')
+            ->willReturn('view_item_list');
 
-        $this->productIdentifierHelper
-            ->method('getProductIdentifier')
-            ->with($product)
-            ->willReturn('PROD-1');
+        $this->viewItemListProvider
+            ->method('getEcommerce')
+            ->with($this->callback(function (array $context) use ($product, $taxon, $channel): bool {
+                return $context[ContextInterface::CONTEXT_PRODUCTS] === [$product] &&
+                    $context[ContextInterface::CONTEXT_TAXON] === $taxon &&
+                    $context[ContextInterface::CONTEXT_CHANNEL] === $channel &&
+                    $context[ContextInterface::CONTEXT_CURRENCY_CODE] === 'EUR';
+            }))
+            ->willReturn($expectedEcommerce);
 
-        $this->productVariantResolver
-            ->method('getVariant')
-            ->with($product)
-            ->willReturn($variant);
-
-        $this->productVariantPriceHelper
-            ->method('getProductVariantPrice')
-            ->with($variant)
-            ->willReturn(1500);
-
-        $query = $this->createMock(Query::class);
-        $query->method('getResult')->willReturn([$product]);
-
-        $queryBuilder = $this->createMock(QueryBuilder::class);
-        $queryBuilder->method('getQuery')->willReturn($query);
-
-        $this->productRepository
-            ->method('createShopListQueryBuilder')
-            ->with($channel, $taxon, 'en_US')
-            ->willReturn($queryBuilder);
-
-        $this->viewItemList->add($taxon, 'sylius_shop_product_index');
+        $this->viewItemList->add($taxon, [$product]);
 
         $push = $this->gtm->getPush();
 
@@ -114,38 +93,14 @@ final class ViewItemListTest extends TestCase
 
         // Second push: view_item_list event
         self::assertEquals('view_item_list', $push[1]['event']);
-        self::assertEquals('sylius_shop_product_index', $push[1]['ecommerce']['item_list_id']);
-        self::assertEquals('Electronics', $push[1]['ecommerce']['item_list_name']);
-
-        $items = $push[1]['ecommerce']['items'];
-        self::assertCount(1, $items);
-        self::assertEquals('PROD-1', $items[0]['item_id']);
-        self::assertEquals('Test Product', $items[0]['item_name']);
-        self::assertEquals('My Store', $items[0]['affiliation']);
-        self::assertEquals('Electronics', $items[0]['item_category']);
-        self::assertEquals(0, $items[0]['index']);
-        self::assertEquals(15.0, $items[0]['price']);
+        self::assertEquals($expectedEcommerce, $push[1]['ecommerce']);
     }
 
     public function testAddDoesNothingWhenNoProducts(): void
     {
         $taxon = $this->createMock(TaxonInterface::class);
-        $channel = $this->createMock(ChannelInterface::class);
 
-        $this->channelContext->method('getChannel')->willReturn($channel);
-        $this->localeContext->method('getLocaleCode')->willReturn('en_US');
-
-        $query = $this->createMock(Query::class);
-        $query->method('getResult')->willReturn([]);
-
-        $queryBuilder = $this->createMock(QueryBuilder::class);
-        $queryBuilder->method('getQuery')->willReturn($query);
-
-        $this->productRepository
-            ->method('createShopListQueryBuilder')
-            ->willReturn($queryBuilder);
-
-        $this->viewItemList->add($taxon);
+        $this->viewItemList->add($taxon, []);
 
         self::assertEmpty($this->gtm->getPush());
     }

--- a/tests/Unit/TagManager/ViewItemListTest.php
+++ b/tests/Unit/TagManager/ViewItemListTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Unit\TagManager;
+
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\ProductIdentifierHelperInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\Helper\ProductVariantPriceHelperInterface;
+use StefanDoorn\SyliusGtmEnhancedEcommercePlugin\TagManager\ViewItemList;
+use Sylius\Component\Channel\Context\ChannelContextInterface;
+use Sylius\Component\Core\Model\ChannelInterface;
+use Sylius\Component\Core\Model\ProductInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Core\Model\TaxonInterface;
+use Sylius\Component\Core\Repository\ProductRepositoryInterface;
+use Sylius\Component\Locale\Context\LocaleContextInterface;
+use Sylius\Component\Product\Resolver\ProductVariantResolverInterface;
+use Xynnn\GoogleTagManagerBundle\Service\GoogleTagManager;
+
+#[CoversClass(ViewItemList::class)]
+final class ViewItemListTest extends TestCase
+{
+    private GoogleTagManager $gtm;
+
+    private MockObject&ProductRepositoryInterface $productRepository;
+
+    private MockObject&ChannelContextInterface $channelContext;
+
+    private MockObject&LocaleContextInterface $localeContext;
+
+    private MockObject&ProductIdentifierHelperInterface $productIdentifierHelper;
+
+    private MockObject&ProductVariantResolverInterface $productVariantResolver;
+
+    private MockObject&ProductVariantPriceHelperInterface $productVariantPriceHelper;
+
+    private ViewItemList $viewItemList;
+
+    protected function setUp(): void
+    {
+        $this->gtm = new GoogleTagManager(true, 'id1234');
+        $this->productRepository = $this->createMock(ProductRepositoryInterface::class);
+        $this->channelContext = $this->createMock(ChannelContextInterface::class);
+        $this->localeContext = $this->createMock(LocaleContextInterface::class);
+        $this->productIdentifierHelper = $this->createMock(ProductIdentifierHelperInterface::class);
+        $this->productVariantResolver = $this->createMock(ProductVariantResolverInterface::class);
+        $this->productVariantPriceHelper = $this->createMock(ProductVariantPriceHelperInterface::class);
+
+        $this->viewItemList = new ViewItemList(
+            $this->gtm,
+            $this->productRepository,
+            $this->channelContext,
+            $this->localeContext,
+            $this->productIdentifierHelper,
+            $this->productVariantResolver,
+            $this->productVariantPriceHelper,
+        );
+    }
+
+    public function testAddPushesViewItemListEvent(): void
+    {
+        $taxon = $this->createMock(TaxonInterface::class);
+        $taxon->method('getName')->willReturn('Electronics');
+
+        $channel = $this->createMock(ChannelInterface::class);
+        $channel->method('getName')->willReturn('My Store');
+
+        $this->channelContext->method('getChannel')->willReturn($channel);
+        $this->localeContext->method('getLocaleCode')->willReturn('en_US');
+
+        $product = $this->createMock(ProductInterface::class);
+        $product->method('getName')->willReturn('Test Product');
+
+        $variant = $this->createMock(ProductVariantInterface::class);
+
+        $this->productIdentifierHelper
+            ->method('getProductIdentifier')
+            ->with($product)
+            ->willReturn('PROD-1');
+
+        $this->productVariantResolver
+            ->method('getVariant')
+            ->with($product)
+            ->willReturn($variant);
+
+        $this->productVariantPriceHelper
+            ->method('getProductVariantPrice')
+            ->with($variant)
+            ->willReturn(1500);
+
+        $query = $this->createMock(Query::class);
+        $query->method('getResult')->willReturn([$product]);
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('getQuery')->willReturn($query);
+
+        $this->productRepository
+            ->method('createShopListQueryBuilder')
+            ->with($channel, $taxon, 'en_US')
+            ->willReturn($queryBuilder);
+
+        $this->viewItemList->add($taxon, 'sylius_shop_product_index');
+
+        $push = $this->gtm->getPush();
+
+        // First push: ecommerce reset
+        self::assertArrayHasKey('ecommerce', $push[0]);
+        self::assertNull($push[0]['ecommerce']);
+
+        // Second push: view_item_list event
+        self::assertEquals('view_item_list', $push[1]['event']);
+        self::assertEquals('sylius_shop_product_index', $push[1]['ecommerce']['item_list_id']);
+        self::assertEquals('Electronics', $push[1]['ecommerce']['item_list_name']);
+
+        $items = $push[1]['ecommerce']['items'];
+        self::assertCount(1, $items);
+        self::assertEquals('PROD-1', $items[0]['item_id']);
+        self::assertEquals('Test Product', $items[0]['item_name']);
+        self::assertEquals('My Store', $items[0]['affiliation']);
+        self::assertEquals('Electronics', $items[0]['item_category']);
+        self::assertEquals(0, $items[0]['index']);
+        self::assertEquals(15.0, $items[0]['price']);
+    }
+
+    public function testAddDoesNothingWhenNoProducts(): void
+    {
+        $taxon = $this->createMock(TaxonInterface::class);
+        $channel = $this->createMock(ChannelInterface::class);
+
+        $this->channelContext->method('getChannel')->willReturn($channel);
+        $this->localeContext->method('getLocaleCode')->willReturn('en_US');
+
+        $query = $this->createMock(Query::class);
+        $query->method('getResult')->willReturn([]);
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('getQuery')->willReturn($query);
+
+        $this->productRepository
+            ->method('createShopListQueryBuilder')
+            ->willReturn($queryBuilder);
+
+        $this->viewItemList->add($taxon);
+
+        self::assertEmpty($this->gtm->getPush());
+    }
+}


### PR DESCRIPTION
## Summary

Refactor `ViewItemList` to delegate to `ViewItemListProvider` and update `ViewItemListListener` to use Sylius grid events. This is **PR 4 of 8**.

## Approach

1. **First commit**: adds a unit test for the current `ViewItemList` behavior
2. **Second commit**: refactors `ViewItemList` to delegate to the provider, updates the listener to use `GenericEvent` + `BreadcrumbComponent`, and adapts the test

## Changes

### Refactored
- `ViewItemList` — now receives products as parameter and delegates to `ViewItemListProvider`
- `ViewItemListInterface` — signature changed: `add(TaxonInterface, array $products)`
- `ViewItemListListener` — now listens on `sylius.product.index`, uses `BreadcrumbComponent` for taxon resolution, extracts products from `GridViewInterface`

### Updated config
- `config/services/tag_managers.yaml` — added ViewItemList service
- `config/services.yaml` — removed old ViewItemList service definition
- `config/features/view_item_list.yaml` — updated listener args and event

### Responsibility shift
The product fetching logic moved FROM `ViewItemList` (TagManager) TO `ViewItemListListener`. The TagManager now only formats and pushes GTM data.

## Verification
- ✅ PHPUnit tests pass (32 tests, 78 assertions)
- ✅ PHPStan passes
- ✅ ECS passes

## Related
- Depends on PR 3 (#229)
- Next: PR 5 (Cart)
